### PR TITLE
[dpub-pwp] move appendix on EPUB3 to before conclusion, and make regular section

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,11 +618,6 @@
       </section>
     </section>
     <section>
-      <h2>Conclusions</h2>
-      <p>This document outlines a vision for the convergence between the Open Web Platform and portable documents while also significantly advancing and expanding the existing digital publishing ecosystem. The realization of this vision would require a strong cooperation between the traditional publishing and Web communities, based on a close collaboration between the W3C and other relevant organizations, like <a href="http://www.idpf.org">IDPF</a>, <a href="http://editeur.org/">EDItEUR</a>, <a href="http://www.bisg.org">BISG</a>, or others. While it is envisaged that most of the work could be done in one or more dedicated Working Groups (within W3C or elsewhere, depending on the exact charter), it must be emphasized that many of the features will affect and will be affected by work done elsewhere, within or outside these organizations. The starting point will be to explore and plan for the detailed technical challenges to gain a better insight into the work ahead; this exploration should be done together with the various interested communities.
-      </p>
-    </section>
-    <section class="appendix">
       <h2 id="epub-relations">Portable Web Publications and EPUB&nbsp;3</h2>
 
       <p>The development of the definitions of <a>Portable Web Publications</a> should not be made in isolation, given the diverse publishing ecosystems that already exist. Rather, the development should rely as much as possible on existing and deployed formats, which include both the various Open Web Platform technologies and digital publishing formats.</p>
@@ -636,5 +631,11 @@
       <p>It must also be emphasized that the central part of any EPUB&nbsp;3 publication, namely the <em>content</em>, will remain unchanged or will require only minimal changes when transitioning towards <a>Portable Web Publications</a>. The bulk of the changes are expected to occur around the accompanying constructs like publication-level metadata records, the spine, or the packaging format of the content. The content of a <a>Portable Web Publications</a> will be based on core Open Web Platform technologies including HTML5, SVG, or CSS3, and many other types of files like images, audio and video, metadata files, executable code in <a href="http://www.ecma-international.org/ecma-262/6.0/index.html">JavaScript</a>, <a href="http://ipython.org/">iPython</a>, <a href="https://jupyter.org/">Jupyter</a>, or <a href="http://www.maplesoft.com/products/maple/">Maple</a> scripts, or datafiles in various formats. Most of these are valid contents in EPUB&nbsp;3 already; a transition towards <a>Portable Web Publications</a> will leave these resources intact. The envisaged changes will be mostly restricted to the implementation details of reading systems and production workflows. The evolution of the past few years of online tooling for the production of EPUB content based on the Open Web Platform (e.g., the platforms developed and used by companies like O’Reilly, Hachette, Metrodigi, or Inkling) will also greatly facilitate any transition to <a>Portable Web Publications</a>; adapting these tools is expected to be quite straightforward.
       </p>
     </section>
+    <section>
+      <h2>Conclusions</h2>
+      <p>This document outlines a vision for the convergence between the Open Web Platform and portable documents while also significantly advancing and expanding the existing digital publishing ecosystem. The realization of this vision would require a strong cooperation between the traditional publishing and Web communities, based on a close collaboration between the W3C and other relevant organizations, like <a href="http://www.idpf.org">IDPF</a>, <a href="http://editeur.org/">EDItEUR</a>, <a href="http://www.bisg.org">BISG</a>, or others. While it is envisaged that most of the work could be done in one or more dedicated Working Groups (within W3C or elsewhere, depending on the exact charter), it must be emphasized that many of the features will affect and will be affected by work done elsewhere, within or outside these organizations. The starting point will be to explore and plan for the detailed technical challenges to gain a better insight into the work ahead; this exploration should be done together with the various interested communities.
+      </p>
+    </section>
+    
   </body>
 </html>


### PR DESCRIPTION
This takes the section on EPUB3, changes it from an appendix to a regular section, and moves it to before the conclusion. The goal is to strengthen the message that PWPs are based on OWP content. I've made no changes to the text. 

Dave
